### PR TITLE
Update NBT data to be in the best format for NBT

### DIFF
--- a/pack/data/minecraft/loot_tables/blocks/shulker_box.json
+++ b/pack/data/minecraft/loot_tables/blocks/shulker_box.json
@@ -14,7 +14,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "nbt": "{drop_contents:true}"
+                    "nbt": "{dropContents:1b}"
                   }
                 }
               ]


### PR DESCRIPTION
Currently, the NBT data predicate in the loot table looks like this:

    "nbt":"{drop_contents:true}"
There are several problems with the wait that this was designed:

- The casing of the name of the data tag does not match the preferred formats of `camelCase` or `PascalCase` used by Minecraft.
- The NBT data type is incorrect, for the following reason:  
  NBT data has never had a true data type for booleans, instead, they use the Byte data type, which holds numbers from &minus;128 to 127. When this loot table was designed, the author thought that NBT had a boolean type similar to JSON, and put `true` in as the data. NBT interprets this as the string `"true"` instead of the Boolean data type.

Therefore, I believe that the NBT data should be updated to the following to take up the smallest amount of data storage:

    "nbt":"{dropContents:1b}"